### PR TITLE
Manually update to node:14.18.1-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6-buster-slim
+FROM node:14.18.1-buster-slim
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends p7zip-full && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #29. See https://github.com/dependabot/dependabot-core/issues/2247 for why this is necessary.