### PR TITLE
Manually update to node:16.13.0-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.1-buster-slim
+FROM node:16.13.0-buster-slim
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends p7zip-full && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #34. See dependabot/dependabot-core#2247 for why this is necessary.