### PR TITLE
Fix bad koa-body upgrade

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -34,9 +34,9 @@ router.post("/wattsi", bodyParser, async ctx => {
   const sha = ctx.request.body.sha || "(sha not provided)";
   const buildType = ctx.request.body.build || "default";
 
-  const sourceFilePath = (ctx.request.files.source && ctx.request.files.source.path) ||
+  const sourceFilePath = (ctx.request.files.source && ctx.request.files.source.filepath) ||
                          ctx.throw(400, "Expected a source file");
-  const mdnFilePath = (ctx.request.files.mdn && ctx.request.files.mdn.path) ||
+  const mdnFilePath = (ctx.request.files.mdn && ctx.request.files.mdn.filepath) ||
                       ctx.throw(400, "Expected a mdn file");
 
   const outDirectory = randomDirectoryName();
@@ -93,6 +93,6 @@ function randomDirectoryName() {
 }
 
 function removeAllFiles(ctx) {
-  const filePaths = Object.values(ctx.request.files).map(file => file.path);
+  const filePaths = Object.values(ctx.request.files).map(file => file.filepath);
   return Promise.all(filePaths.map(filePath => unlink(filePath)));
 }


### PR DESCRIPTION
b4140ef1bdcae4b2d6329d9d6b8733f0c1f25759 changed how koa-body exposes files in a way that broke the server.