### PR TITLE
Move from Wattsi-Exit-Code to Exit-Code header

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also send the following query string parameters, which correspond to the
 
 If the resulting status code is 200, the result will be a ZIP file containing the output, as well as an `output.txt` containing the stdout/stderr output. If the resulting status code is 400, the body text will be the error message.
 
-The response will have a header, `Wattsi-Exit-Code`, which gives the exit code of Wattsi. This will always be `0` for a 200 OK response, but a 400 Bad Request could give a variety of different values, depending on how Wattsi failed.
+The response will have a header, `Exit-Code`, which gives the exit code of Wattsi. This will always be `0` for a 200 OK response, but a 400 Bad Request could give a variety of different values, depending on how Wattsi failed.
 
 ### `/version`
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -55,11 +55,11 @@ router.post("/wattsi", bodyParser, async ctx => {
       const errorBody = e.output ?? e.stack;
       console.log(`  html-build or file-writing failed:`);
       console.log(errorBody);
-      const headers = typeof e.code === "number" ? { "Wattsi-Exit-Code": e.code } : {};
+      const headers = typeof e.code === "number" ? { "Exit-Code": e.code } : {};
       ctx.throw(400, errorBody, { headers });
     }
 
-    ctx.response.set("Wattsi-Exit-Code", "0");
+    ctx.response.set("Exit-Code", "0");
     const zipFilePath = `${outDirectory}.zip`;
     console.log(`  zipping result`);
     await execFile("7za", ["a", "-tzip", "-r", zipFilePath, `${outDirectory}/*`]);


### PR DESCRIPTION
As part of adding a /html-build endpoint, it's nicer to standardize on a single header name for both.

---

This needs to be merged around the same time as the corresponding html-build pull request.